### PR TITLE
Prevent Public Kit load spam and add display name support for %player%

### DIFF
--- a/src/main/java/dev/noah/perplayerkit/gui/GUI.java
+++ b/src/main/java/dev/noah/perplayerkit/gui/GUI.java
@@ -62,6 +62,7 @@ public class GUI {
         slot.setClickHandler((player, info) -> {
             SoundManager.playClick(player);
             KitManager.get().loadPublicKit(player, id);
+            info.getClickedMenu().close();
         });
     }
 
@@ -475,6 +476,7 @@ public class GUI {
             SoundManager.playClick(player);
             if (info.getClickType() == ClickType.LEFT) {
                 KitManager.get().loadPublicKit(player, id);
+                info.getClickedMenu().close();
             } else if (info.getClickType() == ClickType.RIGHT) {
                 Menu m = ViewPublicKitMenu(player, id);
                 if (m != null) {

--- a/src/main/java/dev/noah/perplayerkit/util/BroadcastManager.java
+++ b/src/main/java/dev/noah/perplayerkit/util/BroadcastManager.java
@@ -95,7 +95,15 @@ public class BroadcastManager {
 
         String message = plugin.getConfig().getString(key.getKey(), "<gray><aqua>%player%</aqua> " +
                 "performed an action.</gray>");
-        message = message.replace("%player%", player.getName());
+
+        String playerName;
+        if (plugin.getConfig().getBoolean("use-display-name", false)) {
+            playerName = player.getDisplayName();
+        } else {
+            playerName = player.getName();
+        }
+
+        message = message.replace("%player%", playerName);
 
         broadcastMessage(player, message);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,6 +76,8 @@ publickits:
 
 prefix: "<gray>[<aqua>Kits</aqua>]</gray> "
 
+use-display-name: false #For example, set to true if you want to display nicknames set by other plugins.
+
 messages:
   player-repaired: "<gray>%player% repaired their gear</gray>"
   player-healed: "<gray>%player% healed themselves</gray>"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - The menu now automatically closes after loading a public kit, providing a smoother and more intuitive user experience.
  - Player names in broadcast messages can now display nicknames or default usernames based on a new configuration setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->